### PR TITLE
Set "systems" to "wfrp4e"

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,13 +4,10 @@
   "description": "Functions to generate NPC",
   "version": "1.6.2",
   "minimumCoreVersion": "0.7.9",
-  "compatibleCoreVersion": "0.7.9",
+  "compatibleCoreVersion": "0.7.10",
   "author": "Skeroujvapluvit",
+  "systems": ["wfrp4e"],
   "dependencies": [
-    {
-      "name": "wfrp4e",
-      "type": "system"
-    },
     {
       "name": "wfrp4e-core",
       "type": "module"


### PR DESCRIPTION
If the systems tag is set up, it only shows up in games with the corresponding systems. I also removed the system dependency because with the change there is no need for that anymore.